### PR TITLE
RST-2116 Respondent is now part of respondents collection

### DIFF
--- a/app/views/export_claim_service/top.json.jbuilder
+++ b/app/views/export_claim_service/top.json.jbuilder
@@ -26,21 +26,6 @@ json.set! 'data' do
     json.set! 'claimant_contact_preference', claim.dig('primary_claimant', 'contact_preference')&.humanize
   end
   json.set! 'caseType', 'Single'
-  json.set! 'respondentSumType' do
-    json.set! 'respondent_name', claim.dig('primary_respondent', 'name')
-    json.set! 'respondent_ACAS_question', claim.dig('primary_respondent', 'acas_certificate_number').present? ? 'Yes' : 'No'
-    json.set! 'respondent_address' do
-      json.set! 'AddressLine1', claim.dig('primary_respondent', 'address', 'building')
-      json.set! 'AddressLine2', claim.dig('primary_respondent', 'address', 'street')
-      json.set! 'PostTown', claim.dig('primary_respondent', 'address', 'locality')
-      json.set! 'County', claim.dig('primary_respondent', 'address', 'county')
-      json.set! 'Country', nil
-      json.set! 'PostCode', claim.dig('primary_respondent', 'address', 'post_code')
-    end
-    json.set! 'respondent_phone1', claim.dig('primary_respondent', 'address_telephone_number')
-    json.set! 'respondent_ACAS', claim.dig('primary_respondent', 'acas_certificate_number')
-    json.set! 'respondent_ACAS_no', optional_acas_exemption(claim.dig('primary_respondent', 'acas_exemption_code')) unless claim.dig('primary_respondent', 'acas_certificate_number').present?
-  end
   json.set! 'claimantWorkAddress' do
     if claim.dig('primary_respondent', 'work_address').present?
       json.set! 'claimant_work_address' do
@@ -65,7 +50,7 @@ json.set! 'data' do
     end
   end
   json.set! 'respondentCollection' do
-    json.array!(claim.dig('secondary_respondents')) do |respondent|
+    json.array!([claim['primary_respondent']] + claim.dig('secondary_respondents')) do |respondent|
       json.set! 'value' do
         json.set! 'respondent_name', respondent.dig('name')
         json.set! 'respondent_address' do

--- a/app/views/export_multiple_claims_service/lead_claimant_data.json.jbuilder
+++ b/app/views/export_multiple_claims_service/lead_claimant_data.json.jbuilder
@@ -27,21 +27,6 @@ json.set! 'claimantType' do
   json.set! 'claimant_contact_preference', claim.dig('primary_claimant', 'contact_preference')&.humanize
 end
 json.set! 'caseType', 'Single'
-json.set! 'respondentSumType' do
-  json.set! 'respondent_name', claim.dig('primary_respondent', 'name')
-  json.set! 'respondent_ACAS_question', claim.dig('primary_respondent', 'acas_certificate_number').present? ? 'Yes' : 'No'
-  json.set! 'respondent_address' do
-    json.set! 'AddressLine1', claim.dig('primary_respondent', 'address', 'building')
-    json.set! 'AddressLine2', claim.dig('primary_respondent', 'address', 'street')
-    json.set! 'PostTown', claim.dig('primary_respondent', 'address', 'locality')
-    json.set! 'County', claim.dig('primary_respondent', 'address', 'county')
-    json.set! 'Country', nil
-    json.set! 'PostCode', claim.dig('primary_respondent', 'address', 'post_code')
-  end
-  json.set! 'respondent_phone1', claim.dig('primary_respondent', 'address_telephone_number')
-  json.set! 'respondent_ACAS', claim.dig('primary_respondent', 'acas_certificate_number')
-  json.set! 'respondent_ACAS_no', optional_acas_exemption(claim.dig('primary_respondent', 'acas_exemption_code')) unless claim.dig('primary_respondent', 'acas_certificate_number').present?
-end
 json.set! 'claimantWorkAddress' do
   if claim.dig('primary_respondent', 'work_address').present?
     json.set! 'claimant_work_address' do
@@ -66,7 +51,7 @@ json.set! 'claimantWorkAddress' do
   end
 end
 json.set! 'respondentCollection' do
-  json.array!(claim.dig('secondary_respondents')) do |respondent|
+  json.array!([claim['primary_respondent']] + claim.dig('secondary_respondents')) do |respondent|
     json.set! 'value' do
       json.set! 'respondent_name', respondent.dig('name')
       json.set! 'respondent_address' do

--- a/app/views/export_multiple_claims_service/secondary_claimant_data.json.jbuilder
+++ b/app/views/export_multiple_claims_service/secondary_claimant_data.json.jbuilder
@@ -28,24 +28,9 @@ json.set! 'claimantType' do
 
 end
 json.set! 'caseType', 'Single'
-json.set! 'respondentSumType' do
-  json.set! 'respondent_name', claim.dig('primary_respondent', 'name')
-  json.set! 'respondent_ACAS_question', claim.dig('primary_respondent', 'acas_certificate_number').present? ? 'Yes' : 'No'
-  json.set! 'respondent_address' do
-    json.set! 'AddressLine1', claim.dig('primary_respondent', 'address', 'building')
-    json.set! 'AddressLine2', claim.dig('primary_respondent', 'address', 'street')
-    json.set! 'PostTown', claim.dig('primary_respondent', 'address', 'locality')
-    json.set! 'County', claim.dig('primary_respondent', 'address', 'county')
-    json.set! 'Country', nil
-    json.set! 'PostCode', claim.dig('primary_respondent', 'address', 'post_code')
-  end
-  json.set! 'respondent_phone1', claim.dig('primary_respondent', 'address_telephone_number')
-  json.set! 'respondent_ACAS', claim.dig('primary_respondent', 'acas_certificate_number')
-  json.set! 'respondent_ACAS_no', optional_acas_exemption(claim.dig('primary_respondent', 'acas_exemption_code')) unless claim.dig('primary_respondent', 'acas_certificate_number').present?
-end
 json.set! 'claimantWorkAddress', {}
 json.set! 'respondentCollection' do
-  json.array!(claim.dig('secondary_respondents')) do |respondent|
+  json.array!([claim['primary_respondent']] + claim.dig('secondary_respondents')) do |respondent|
     json.set! 'value' do
       json.set! 'respondent_name', respondent.dig('name')
       json.set! 'respondent_address' do
@@ -84,3 +69,4 @@ if claim.dig('primary_representative').present?
     json.set! 'representative_dx', claim.dig('primary_representative', 'dx_number')
   end
 end
+json.set! 'documentCollection', []

--- a/spec/json_schemas/case_create.json
+++ b/spec/json_schemas/case_create.json
@@ -93,14 +93,22 @@
           "pattern": "^(.*)$"
         },
         "claimant_gender": {
-          "$id": "#/properties/data/properties/claimantIndType/properties/claimant_gender",
-          "type": "string",
-          "title": "The Claimant_gender Schema",
-          "default": "",
-          "examples": [
-            "Male"
-          ],
-          "pattern": "^(.*)$"
+          "oneOf": [
+            {
+              "$id": "#/properties/data/properties/claimantIndType/properties/claimant_gender",
+              "type": "string",
+              "title": "The Claimant_gender Schema",
+              "default": "",
+              "examples": [
+                "Male"
+              ],
+              "pattern": "^(.*)$"
+            },
+            {
+              "$id": "#/properties/data/properties/claimantIndType/properties/claimant_gender",
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -191,172 +199,76 @@
           }
         },
         "claimant_phone_number": {
-          "$id": "#/properties/data/properties/claimantType/properties/claimant_phone_number",
-          "type": "string",
-          "title": "The Claimant_phone_number Schema",
-          "default": "",
-          "examples": [
-            "01234 567890"
-          ],
-          "pattern": "^(.*)$"
+          "oneOf": [
+            {
+              "$id": "#/properties/data/properties/claimantType/properties/claimant_phone_number",
+              "type": "string",
+              "title": "The Claimant_phone_number Schema",
+              "default": "",
+              "examples": [
+                "01234 567890"
+              ],
+              "pattern": "^(.*)$"
+            },
+            {
+              "$id": "#/properties/data/properties/claimantType/properties/claimant_phone_number",
+              "type": "null"
+            }
+          ]
         },
         "claimant_mobile_number": {
-          "$id": "#/properties/data/properties/claimantType/properties/claimant_mobile_number",
-          "type": "string",
-          "title": "The Claimant_mobile_number Schema",
-          "default": "",
-          "examples": [
-            "01234 098765"
-          ],
-          "pattern": "^(.*)$"
+          "oneOf": [
+            {
+              "$id": "#/properties/data/properties/claimantType/properties/claimant_mobile_number",
+              "type": "string",
+              "title": "The Claimant_mobile_number Schema",
+              "default": "",
+              "examples": [
+                "01234 098765"
+              ],
+              "$id": "#/properties/data/properties/claimantType/properties/claimant_mobile_number",
+              "pattern": "^(.*)$"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "claimant_email_address": {
-          "$id": "#/properties/data/properties/claimantType/properties/claimant_email_address",
-          "type": "string",
-          "title": "The Claimant_email_address Schema",
-          "default": "",
-          "examples": [
-            "sivvoy.taing@hmcts.net"
-          ],
-          "pattern": "^(.*)$"
+          "oneOf": [
+            {
+              "$id": "#/properties/data/properties/claimantType/properties/claimant_email_address",
+              "type": "string",
+              "title": "The Claimant_email_address Schema",
+              "default": "",
+              "examples": [
+                "sivvoy.taing@hmcts.net"
+              ],
+              "pattern": "^(.*)$"
+            },
+            {
+              "$id": "#/properties/data/properties/claimantType/properties/claimant_email_address",
+              "type": "null"
+            }
+          ]
         },
         "claimant_contact_preference": {
-          "$id": "#/properties/data/properties/claimantType/properties/claimant_contact_preference",
-          "type": "string",
-          "title": "The Claimant_contact_preference Schema",
-          "default": "",
-          "examples": [
-            "Email"
-          ],
-          "pattern": "^(.*)$"
-        }
-      }
-    },
-    "respondent_sum_type": {
-      "$id": "#/properties/data/properties/respondentSumType",
-      "type": "object",
-      "title": "The Respondentsumtype Schema",
-      "required": [
-        "respondent_name",
-        "respondent_ACAS_question",
-        "respondent_address",
-        "respondent_phone1",
-        "respondent_ACAS"
-      ],
-      "properties": {
-        "respondent_name": {
-          "$id": "#/properties/data/properties/respondentSumType/properties/respondent_name",
-          "type": "string",
-          "title": "The Respondent_name Schema",
-          "default": "",
-          "examples": [
-            "Torphy-Bernhard"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "respondent_ACAS_question": {
-          "$id": "#/properties/data/properties/respondentSumType/properties/respondent_ACAS_question",
-          "type": "string",
-          "title": "The Respondent_acas_question Schema",
-          "default": "",
-          "examples": [
-            "Yes"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "respondent_address": {
-          "$id": "#/properties/data/properties/respondentSumType/properties/respondent_address",
-          "type": "object",
-          "title": "The Respondent_address Schema",
-          "required": [
-            "AddressLine1",
-            "AddressLine2",
-            "PostTown",
-            "County",
-            "Country",
-            "PostCode"
-          ],
-          "properties": {
-            "AddressLine1": {
-              "$id": "#/properties/data/properties/respondentSumType/properties/respondent_address/properties/AddressLine1",
+          "oneOf": [
+            {
+              "$id": "#/properties/data/properties/claimantType/properties/claimant_contact_preference",
               "type": "string",
-              "title": "The Addressline1 Schema",
+              "title": "The Claimant_contact_preference Schema",
               "default": "",
               "examples": [
-                "1779"
+                "Email"
               ],
               "pattern": "^(.*)$"
             },
-            "AddressLine2": {
-              "$id": "#/properties/data/properties/respondentSumType/properties/respondent_address/properties/AddressLine2",
-              "type": "string",
-              "title": "The Addressline2 Schema",
-              "default": "",
-              "examples": [
-                "Juvenal Shores"
-              ],
-              "pattern": "^(.*)$"
-            },
-            "PostTown": {
-              "$id": "#/properties/data/properties/respondentSumType/properties/respondent_address/properties/PostTown",
-              "type": "string",
-              "title": "The Posttown Schema",
-              "default": "",
-              "examples": [
-                "London"
-              ],
-              "pattern": "^(.*)$"
-            },
-            "County": {
-              "$id": "#/properties/data/properties/respondentSumType/properties/respondent_address/properties/County",
-              "type": "string",
-              "title": "The County Schema",
-              "default": "",
-              "examples": [
-                "Greater London"
-              ],
-              "pattern": "^(.*)$"
-            },
-            "Country": {
-              "$id": "#/properties/data/properties/respondentSumType/properties/respondent_address/properties/Country",
-              "type": "null",
-              "title": "The Country Schema",
-              "default": null,
-              "examples": [
-                null
-              ]
-            },
-            "PostCode": {
-              "$id": "#/properties/data/properties/respondentSumType/properties/respondent_address/properties/PostCode",
-              "type": "string",
-              "title": "The Postcode Schema",
-              "default": "",
-              "examples": [
-                "SW1H 9QR"
-              ],
-              "pattern": "^(.*)$"
+            {
+              "$id": "#/properties/data/properties/claimantType/properties/claimant_contact_preference",
+              "type": "null"
             }
-          }
-        },
-        "respondent_phone1": {
-          "$id": "#/properties/data/properties/respondentSumType/properties/respondent_phone1",
-          "type": "string",
-          "title": "The Respondent_phone1 Schema",
-          "default": "",
-          "examples": [
-            "02222 321654"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "respondent_ACAS": {
-          "$id": "#/properties/data/properties/respondentSumType/properties/respondent_ACAS",
-          "type": "string",
-          "title": "The Respondent_acas Schema",
-          "default": "",
-          "examples": [
-            "AC123456/78/90"
-          ],
-          "pattern": "^(.*)$"
+          ]
         }
       }
     },
@@ -752,12 +664,26 @@
               }
             },
             "respondent_phone1": {
-              "$id": "#/properties/data/properties/respondentCollection/items/properties/value/properties/respondent_phone1",
-              "type": "null",
-              "title": "The Respondent_phone1 Schema",
-              "default": null,
-              "examples": [
-                null
+              "oneOf": [
+                {
+                  "$id": "#/properties/data/properties/respondentCollection/items/properties/value/properties/respondent_phone1",
+                  "type": "string",
+                  "title": "The Respondent_phone1 Schema",
+                  "default": "",
+                  "examples": [
+                    "02222 321654"
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                {
+                  "$id": "#/properties/data/properties/respondentCollection/items/properties/value/properties/respondent_phone1",
+                  "type": "null",
+                  "title": "The Respondent_phone1 Schema",
+                  "default": null,
+                  "examples": [
+                    null
+                  ]
+                }
               ]
             },
             "respondent_ACAS": {
@@ -898,7 +824,6 @@
     "claimantIndType",
     "claimantType",
     "caseType",
-    "respondentSumType",
     "claimantWorkAddress",
     "respondentCollection",
     "claimantOtherType",
@@ -907,7 +832,14 @@
     "positionType",
     "documentCollection"
   ],
+  "additionalProperties": false,
   "properties": {
+    "ethosCaseReference": {
+      "type": "string",
+      "title": "The ethos case reference",
+      "default": "",
+      "examples": "01234567890"
+    },
     "receiptDate": {
       "type": "string",
       "title": "The Receipt date Schema",
@@ -965,15 +897,32 @@
       ],
       "enum": ["Single", "Multiple"]
     },
-    "respondentSumType": { "$ref": "#/definitions/respondent_sum_type" },
-    "claimantWorkAddress": { "$ref": "#/definitions/claimant_work_address"},
+    "claimantWorkAddress": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/claimant_work_address"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false
+        }
+      ]
+    },
     "respondentCollection": {
       "$id": "#/properties/data/properties/respondentCollection",
       "type": "array",
       "title": "The Respondent collection Schema",
       "items":{ "$ref": "#/definitions/respondent_for_collection"}
     },
-    "claimantOtherType": { "$ref": "#/definitions/claimant_other_type"},
+    "claimantOtherType": {
+      "oneOf": [
+        { "$ref": "#/definitions/claimant_other_type" },
+        {
+          "type": "object",
+          "additionalProperties": false
+        }
+      ]
+    },
     "claimantRepresentedQuestion": {
       "$id": "#/properties/data/properties/claimantRepresentedQuestion",
       "type": "string",

--- a/spec/presenters/claim_presenter_spec.rb
+++ b/spec/presenters/claim_presenter_spec.rb
@@ -197,69 +197,6 @@ RSpec.describe ClaimPresenter do
       it { is_expected.to present_ccd_field('representativeClaimantType.representative_dx').using(:claim, primary_representative_attrs: { dx_number: nil }).with_result(nil) }
     end
 
-    context 'with respondentSumType.respondent_name' do
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_name').using(:claim, primary_respondent_attrs: { name: 'Name 1' }).with_result('Name 1') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_name').using(:claim, primary_respondent_attrs: { name: 'Name 2' }).with_result('Name 2') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_name').using(:claim, primary_respondent_attrs: { name: nil }).with_result(nil) }
-    end
-
-    context 'with respondentSumType.respondent_address.AddressLine1' do
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.AddressLine1').using(:claim, primary_respondent_attrs: { address: build(:address, building: 'Building 1') }).with_result('Building 1') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.AddressLine1').using(:claim, primary_respondent_attrs: { address: build(:address, building: 'Building 2') }).with_result('Building 2') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.AddressLine1').using(:claim, primary_respondent_attrs: { address: build(:address, building: nil) }).with_result(nil) }
-    end
-
-    context 'with respondentSumType.respondent_address.AddressLine2' do
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.AddressLine2').using(:claim, primary_respondent_attrs: { address: build(:address, street: 'Street 1') }).with_result('Street 1') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.AddressLine2').using(:claim, primary_respondent_attrs: { address: build(:address, street: 'Street 2') }).with_result('Street 2') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.AddressLine2').using(:claim, primary_respondent_attrs: { address: build(:address, street: nil) }).with_result(nil) }
-    end
-
-    context 'with respondentSumType.respondent_address.PostTown' do
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.PostTown').using(:claim, primary_respondent_attrs: { address: build(:address, locality: 'Town 1') }).with_result('Town 1') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.PostTown').using(:claim, primary_respondent_attrs: { address: build(:address, locality: 'Town 2') }).with_result('Town 2') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.PostTown').using(:claim, primary_respondent_attrs: { address: build(:address, locality: nil) }).with_result(nil) }
-    end
-
-    context 'with respondentSumType.respondent_address.County' do
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.County').using(:claim, primary_respondent_attrs: { address: build(:address, county: 'County 1') }).with_result('County 1') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.County').using(:claim, primary_respondent_attrs: { address: build(:address, county: 'County 2') }).with_result('County 2') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.County').using(:claim, primary_respondent_attrs: { address: build(:address, county: nil) }).with_result(nil) }
-    end
-
-    context 'with respondentSumType.respondent_address.PostCode' do
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.PostCode').using(:claim, primary_respondent_attrs: { address: build(:address, post_code: 'Postcode 1') }).with_result('Postcode 1') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.PostCode').using(:claim, primary_respondent_attrs: { address: build(:address, post_code: 'Postcode 2') }).with_result('Postcode 2') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_address.PostCode').using(:claim, primary_respondent_attrs: { address: build(:address, post_code: nil) }).with_result(nil) }
-    end
-
-    context 'with respondentSumType.respondent_phone1' do
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_phone1').using(:claim, primary_respondent_attrs: { address_telephone_number: 'Number 1' }).with_result('Number 1') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_phone1').using(:claim, primary_respondent_attrs: { address_telephone_number: 'Number 2' }).with_result('Number 2') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_phone1').using(:claim, primary_respondent_attrs: { address_telephone_number: nil }).with_result(nil) }
-    end
-
-    context 'with respondentSumType.respondent_ACAS' do
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS').using(:claim, primary_respondent_attrs: { acas_certificate_number: 'Cert 1' }).with_result('Cert 1') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS').using(:claim, primary_respondent_attrs: { acas_certificate_number: 'Cert 2' }).with_result('Cert 2') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS').using(:claim, primary_respondent_attrs: { acas_certificate_number: nil }).with_result(nil) }
-    end
-
-    context 'with respondentSumType.respondent_ACAS_question' do
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS_question').using(:claim).with_result('Yes') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS_question').using(:claim, primary_respondent_attrs: { acas_certificate_number: '' }).with_result('No') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS_question').using(:claim, primary_respondent_attrs: { acas_certificate_number: nil }).with_result('No') }
-    end
-
-    context 'with respondentSumType.respondent_ACAS_no' do
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS_no').using(:claim, primary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'joint_claimant_has_acas_number' }).with_result('Another person') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS_no').using(:claim, primary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'acas_has_no_jurisdiction' }).with_result('No Power') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS_no').using(:claim, primary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'employer_contacted_acas' }).with_result('Employer already in touch') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS_no').using(:claim, primary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'interim_relief' }).with_result('Unfair Dismissal') }
-      it { is_expected.to present_ccd_field('respondentSumType.respondent_ACAS_no').using(:claim, primary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: nil }).with_result(nil) }
-      it { is_expected.not_to present_ccd_field('respondentSumType.respondent_ACAS_no').using(:claim, primary_respondent_attrs: { acas_certificate_number: 'Some number' }) }
-    end
-
     context 'with claimantWorkAddress.claimant_work_address.AddressLine1' do
       it { is_expected.to present_ccd_field('claimantWorkAddress.claimant_work_address.AddressLine1').using(:claim, primary_respondent_attrs: { work_address: build(:address, building: 'Building 1') }).with_result('Building 1') }
       it { is_expected.to present_ccd_field('claimantWorkAddress.claimant_work_address.AddressLine1').using(:claim, primary_respondent_attrs: { work_address: build(:address, building: 'Building 2') }).with_result('Building 2') }
@@ -315,66 +252,129 @@ RSpec.describe ClaimPresenter do
     end
 
     context 'with respondentCollection[0].value.respondent_name' do
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_name').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { name: 'Name 1' }).with_result('Name 1') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_name').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { name: 'Name 2' }).with_result('Name 2') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_name').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { name: nil }).with_result(nil) }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_name').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { name: 'Name 1' }).with_result('Name 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_name').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { name: 'Name 2' }).with_result('Name 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_name').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { name: nil }).with_result(nil) }
     end
 
     context 'with respondentCollection[0].value.respondent_address.AddressLine1' do
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, building: 'Building 1') }).with_result('Building 1') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, building: 'Building 2') }).with_result('Building 2') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, building: nil) }).with_result(nil) }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine1').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, building: 'Building 1') }).with_result('Building 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine1').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, building: 'Building 2') }).with_result('Building 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine1').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, building: nil) }).with_result(nil) }
     end
 
     context 'with respondentCollection[0].value.respondent_address.AddressLine2' do
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine2').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, street: 'Street 1') }).with_result('Street 1') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine2').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, street: 'Street 2') }).with_result('Street 2') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine2').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, street: nil) }).with_result(nil) }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine2').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, street: 'Street 1') }).with_result('Street 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine2').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, street: 'Street 2') }).with_result('Street 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.AddressLine2').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, street: nil) }).with_result(nil) }
     end
 
     context 'with respondentCollection[0].value.respondent_address.PostTown' do
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostTown').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, locality: 'Town 1') }).with_result('Town 1') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostTown').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, locality: 'Town 2') }).with_result('Town 2') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostTown').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, locality: nil) }).with_result(nil) }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostTown').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, locality: 'Town 1') }).with_result('Town 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostTown').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, locality: 'Town 2') }).with_result('Town 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostTown').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, locality: nil) }).with_result(nil) }
     end
 
     context 'with respondentCollection[0].value.respondent_address.County' do
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.County').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, county: 'County 1') }).with_result('County 1') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.County').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, county: 'County 2') }).with_result('County 2') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.County').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, county: nil) }).with_result(nil) }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.County').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, county: 'County 1') }).with_result('County 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.County').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, county: 'County 2') }).with_result('County 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.County').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, county: nil) }).with_result(nil) }
     end
 
     context 'with respondentCollection[0].value.respondent_address.PostCode' do
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostCode').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, post_code: 'Postcode 1') }).with_result('Postcode 1') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostCode').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, post_code: 'Postcode 2') }).with_result('Postcode 2') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostCode').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, post_code: nil) }).with_result(nil) }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostCode').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, post_code: 'Postcode 1') }).with_result('Postcode 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostCode').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, post_code: 'Postcode 2') }).with_result('Postcode 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_address.PostCode').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address: build(:address, post_code: nil) }).with_result(nil) }
     end
 
     context 'with respondentCollection[0].value.respondent_phone1' do
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_phone1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address_telephone_number: 'Number 1' }).with_result('Number 1') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_phone1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address_telephone_number: 'Number 2' }).with_result('Number 2') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_phone1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address_telephone_number: nil }).with_result(nil) }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_phone1').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address_telephone_number: 'Number 1' }).with_result('Number 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_phone1').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address_telephone_number: 'Number 2' }).with_result('Number 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_phone1').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { address_telephone_number: nil }).with_result(nil) }
     end
 
     context 'with respondentCollection[0].value.respondent_ACAS' do
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: 'Cert 1' }).with_result('Cert 1') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: 'Cert 2' }).with_result('Cert 2') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil }).with_result(nil) }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: 'Cert 1' }).with_result('Cert 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: 'Cert 2' }).with_result('Cert 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: nil }).with_result(nil) }
     end
 
     context 'with respondentCollection[0].value.respondent_ACAS_question' do
       it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_question').using(:claim, number_of_respondents: 2).with_result('Yes') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_question').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: '' }).with_result('No') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_question').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil }).with_result('No') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_question').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: '' }).with_result('No') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_question').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: nil }).with_result('No') }
     end
 
     context 'with respondentCollection[0].value.respondent_ACAS_no' do
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'joint_claimant_has_acas_number' }).with_result('Another person') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'acas_has_no_jurisdiction' }).with_result('No Power') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'employer_contacted_acas' }).with_result('Employer already in touch') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'interim_relief' }).with_result('Unfair Dismissal') }
-      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: nil }).with_result(nil) }
-      it { is_expected.not_to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: 'Some number' }) }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'joint_claimant_has_acas_number' }).with_result('Another person') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'acas_has_no_jurisdiction' }).with_result('No Power') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'employer_contacted_acas' }).with_result('Employer already in touch') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'interim_relief' }).with_result('Unfair Dismissal') }
+      it { is_expected.to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: nil }).with_result(nil) }
+      it { is_expected.not_to present_ccd_field('respondentCollection[0].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, primary_respondent_attrs: { acas_certificate_number: 'Some number' }) }
+    end
+
+    context 'with respondentCollection[1].value.respondent_name' do
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_name').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { name: 'Name 1' }).with_result('Name 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_name').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { name: 'Name 2' }).with_result('Name 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_name').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { name: nil }).with_result(nil) }
+    end
+
+    context 'with respondentCollection[1].value.respondent_address.AddressLine1' do
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.AddressLine1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, building: 'Building 1') }).with_result('Building 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.AddressLine1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, building: 'Building 2') }).with_result('Building 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.AddressLine1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, building: nil) }).with_result(nil) }
+    end
+
+    context 'with respondentCollection[1].value.respondent_address.AddressLine2' do
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.AddressLine2').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, street: 'Street 1') }).with_result('Street 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.AddressLine2').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, street: 'Street 2') }).with_result('Street 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.AddressLine2').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, street: nil) }).with_result(nil) }
+    end
+
+    context 'with respondentCollection[1].value.respondent_address.PostTown' do
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.PostTown').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, locality: 'Town 1') }).with_result('Town 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.PostTown').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, locality: 'Town 2') }).with_result('Town 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.PostTown').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, locality: nil) }).with_result(nil) }
+    end
+
+    context 'with respondentCollection[1].value.respondent_address.County' do
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.County').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, county: 'County 1') }).with_result('County 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.County').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, county: 'County 2') }).with_result('County 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.County').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, county: nil) }).with_result(nil) }
+    end
+
+    context 'with respondentCollection[1].value.respondent_address.PostCode' do
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.PostCode').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, post_code: 'Postcode 1') }).with_result('Postcode 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.PostCode').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, post_code: 'Postcode 2') }).with_result('Postcode 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_address.PostCode').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address: build(:address, post_code: nil) }).with_result(nil) }
+    end
+
+    context 'with respondentCollection[1].value.respondent_phone1' do
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_phone1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address_telephone_number: 'Number 1' }).with_result('Number 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_phone1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address_telephone_number: 'Number 2' }).with_result('Number 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_phone1').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { address_telephone_number: nil }).with_result(nil) }
+    end
+
+    context 'with respondentCollection[1].value.respondent_ACAS' do
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: 'Cert 1' }).with_result('Cert 1') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: 'Cert 2' }).with_result('Cert 2') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil }).with_result(nil) }
+    end
+
+    context 'with respondentCollection[1].value.respondent_ACAS_question' do
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS_question').using(:claim, number_of_respondents: 2).with_result('Yes') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS_question').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: '' }).with_result('No') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS_question').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil }).with_result('No') }
+    end
+
+    context 'with respondentCollection[1].value.respondent_ACAS_no' do
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'joint_claimant_has_acas_number' }).with_result('Another person') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'acas_has_no_jurisdiction' }).with_result('No Power') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'employer_contacted_acas' }).with_result('Employer already in touch') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: 'interim_relief' }).with_result('Unfair Dismissal') }
+      it { is_expected.to present_ccd_field('respondentCollection[1].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: nil, acas_exemption_code: nil }).with_result(nil) }
+      it { is_expected.not_to present_ccd_field('respondentCollection[1].value.respondent_ACAS_no').using(:claim, number_of_respondents: 2, secondary_respondent_attrs: { acas_certificate_number: 'Some number' }) }
     end
 
     context 'with claimantOtherType.claimant_employed_currently' do


### PR DESCRIPTION

### JIRA link (if applicable) ###

RST-2116

### Change description ###

This PR changes the format of the data being sent to CCD - the primary respondent is now just the first respondent in the collection rather than having its own object.

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```

This change will be coordinated with the CCD team who are driving the change - should be going live at 13:30 on 3/9/2019.
We may get data integrity issues as jobs will be sent to CCD in the old format when the new format is expected etc...  however, this does not matter at the moment as noone is relying on the data going into CCD - we are in  a parallel running phase