### PR TITLE
RST-2196 (CCD Exporter) - MULTIPLES: ET1 is not setting the title in …

### DIFF
--- a/app/presenters/multiple_claims_header_presenter.rb
+++ b/app/presenters/multiple_claims_header_presenter.rb
@@ -1,5 +1,5 @@
 class MultipleClaimsHeaderPresenter
-  def self.present(primary_reference:, case_references:, event_token:)
-    ::ApplicationController.render(template: 'export_multiple_claims_service/header.json.jbuilder', locals: { primary_reference: primary_reference, case_references: case_references, event_token: event_token })
+  def self.present(primary_reference:, case_references:, event_token:, respondent_name:)
+    ::ApplicationController.render(template: 'export_multiple_claims_service/header.json.jbuilder', locals: { primary_reference: primary_reference, respondent_name: respondent_name, case_references: case_references, event_token: event_token })
   end
 end

--- a/app/views/export_multiple_claims_service/header.json.jbuilder
+++ b/app/views/export_multiple_claims_service/header.json.jbuilder
@@ -1,5 +1,5 @@
 json.data do
-  json.bulkCaseTitle ""
+  json.bulkCaseTitle respondent_name
   json.multipleReference primary_reference
   json.caseIdCollection(case_references) do |case_ref|
     json.id nil

--- a/app/workers/export_multiples_header_worker.rb
+++ b/app/workers/export_multiples_header_worker.rb
@@ -2,7 +2,7 @@ class ExportMultiplesHeaderWorker
   include Sidekiq::Worker
   sidekiq_options queue: 'external_system_ccd'
 
-  def perform(primary_reference, case_references, case_type_id, service: ExportMultipleClaimsService.new)
-    service.export_header(primary_reference, case_references, case_type_id)
+  def perform(primary_reference, respondent_name, case_references, case_type_id, service: ExportMultipleClaimsService.new)
+    service.export_header(primary_reference, respondent_name, case_references, case_type_id)
   end
 end

--- a/spec/integration/create_claim_multiples_spec.rb
+++ b/spec/integration/create_claim_multiples_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe "create claim multiples" do
     # Assert - After calling all of our workers like sidekiq would, check with CCD (or fake CCD) to see what we sent
     ccd_case = test_ccd_client.caseworker_search_latest_by_multiple_reference(export.resource.reference, case_type_id: 'Manchester_Multiples_Dev')
     aggregate_failures 'validating key fields' do
-      expect(ccd_case['case_fields']).to include 'multipleReference' => export.resource.reference
+      expect(ccd_case['case_fields']).to include 'multipleReference' => export.resource.reference,
+                                                 'bulkCaseTitle' => export.resource.primary_respondent.name
       case_references = ccd_case.dig('case_fields', 'caseIdCollection').map { |obj| obj.dig('value', 'ethos_CaseReference') }
       expect(case_references.length).to eql(export.resource.secondary_claimants.length + 1)
       expect(case_references).to all be_an_instance_of(String)

--- a/spec/presenters/multiple_claims_header_presenter_spec.rb
+++ b/spec/presenters/multiple_claims_header_presenter_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 RSpec.describe MultipleClaimsHeaderPresenter do
   subject(:presenter) { described_class }
   let(:example_primary_reference) { "123456789012" }
+  let(:example_respondent_name) { 'Dodgy Co' }
   let(:example_case_references) do
     [
       'ExampleCase01',
@@ -20,15 +21,23 @@ RSpec.describe MultipleClaimsHeaderPresenter do
 
   it 'presents the multipleReference' do
     # Act
-    result = JSON.parse(subject.present(primary_reference: example_primary_reference, case_references: example_case_references, event_token: example_event_token))
+    result = JSON.parse(subject.present(primary_reference: example_primary_reference, respondent_name: example_respondent_name, case_references: example_case_references, event_token: example_event_token))
 
     # Assert
     expect(result.dig('data', 'multipleReference')).to eql example_primary_reference
   end
 
+  it 'presents the bulkCaseTitle' do
+    # Act
+    result = JSON.parse(subject.present(primary_reference: example_primary_reference, respondent_name: example_respondent_name, case_references: example_case_references, event_token: example_event_token))
+
+    # Assert
+    expect(result.dig('data', 'bulkCaseTitle')).to eql example_respondent_name
+  end
+
   it 'presents the caseIdCollection' do
     # Act
-    result = JSON.parse(subject.present(primary_reference: example_primary_reference, case_references: example_case_references, event_token: example_event_token))
+    result = JSON.parse(subject.present(primary_reference: example_primary_reference, respondent_name: example_respondent_name, case_references: example_case_references, event_token: example_event_token))
 
     # Assert
     expected_collection = example_case_references.map do |ref|
@@ -44,7 +53,7 @@ RSpec.describe MultipleClaimsHeaderPresenter do
 
   it 'presents the event object' do
     # Act
-    result = JSON.parse(subject.present(primary_reference: example_primary_reference, case_references: example_case_references, event_token: example_event_token))
+    result = JSON.parse(subject.present(primary_reference: example_primary_reference, respondent_name: example_respondent_name, case_references: example_case_references, event_token: example_event_token))
 
     # Assert
     expect(result['event']).to include 'id' => 'createBulkAction',
@@ -54,7 +63,7 @@ RSpec.describe MultipleClaimsHeaderPresenter do
 
   it 'presents the event_token' do
     # Act
-    result = JSON.parse(subject.present(primary_reference: example_primary_reference, case_references: example_case_references, event_token: example_event_token))
+    result = JSON.parse(subject.present(primary_reference: example_primary_reference, respondent_name: example_respondent_name, case_references: example_case_references, event_token: example_event_token))
 
     # Assert
     expect(result['event_token']).to eql example_event_token

--- a/spec/services/export_multiple_claims_service_spec.rb
+++ b/spec/services/export_multiple_claims_service_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe ExportMultipleClaimsService do
         ::Sidekiq::Worker.drain_all
 
         # Assert - Check the batch
-        expect(mock_header_worker).to have_received(:perform).with(example_export.resource.reference, match_array((1000001..(1000001 + example_export.resource.secondary_claimants.length)).to_a.map(&:to_s)), 'Manchester_Multiples_Dev')
+        expect(mock_header_worker).to have_received(:perform).with(example_export.resource.reference, example_export.resource.primary_respondent.name, match_array((1000001..(1000001 + example_export.resource.secondary_claimants.length)).to_a.map(&:to_s)), 'Manchester_Multiples_Dev')
       end
 
       it 'queues the worker 11 times with the data from the presenter' do


### PR DESCRIPTION



### JIRA link (if applicable) ###

RST-2196

### Change description ###

RST-2196 (CCD Exporter) - MULTIPLES: ET1 is not setting the title in the multiples header record

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
