### PR TITLE
JSON Schema validation for fixed lists (tests only)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :test do
   gem 'rspec-rails', '~> 3.9'
   gem 'factory_bot', '~> 5.0', '>= 5.0.2'
   gem 'jsonpath', '~> 1.0'
-  gem 'et_fake_ccd', '~> 0.1'
+  gem 'et_fake_ccd', '~> 1.0'
   gem 'json_matchers', '~> 0.11.0'
   gem 'ice_nine', '~> 0.11.2'
   gem 'mock_redis', '~> 0.22'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.9.0)
-    et_fake_ccd (0.1.39)
+    et_fake_ccd (1.0.0)
       activemodel (>= 5.2.3)
       iodine (~> 0.7)
       json-schema (~> 2.5)
@@ -285,7 +285,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   et_ccd_client!
-  et_fake_ccd (~> 0.1)
+  et_fake_ccd (~> 1.0)
   factory_bot (~> 5.0, >= 5.0.2)
   ice_nine (~> 0.11.2)
   jbuilder (~> 2.9, >= 2.9.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.9.0)
-    et_fake_ccd (1.0.0)
+    et_fake_ccd (1.0.1)
       activemodel (>= 5.2.3)
       iodine (~> 0.7)
       json-schema (~> 2.5)

--- a/spec/factories/respondent_factory.rb
+++ b/spec/factories/respondent_factory.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     trait :full do
       sequence(:name) { |idx| "dodgy_co #{idx}" }
       address { build(:address) }
-      work_address_telephone_number { "" }
+      work_address_telephone_number { "01234 567891" }
       address_telephone_number { "01234 567890" }
       work_address { build(:address) }
       alt_phone_number { "0333 321090" }

--- a/spec/json_schemas/case_create.json
+++ b/spec/json_schemas/case_create.json
@@ -60,7 +60,9 @@
           "examples": [
             "Miss"
           ],
-          "pattern": "^(.*)$"
+          "enum": [
+            "Mr", "Mrs", "Miss", "Ms", "Dr", "Prof", "Sir", "Lord", "Lady", "Dame", "Capt", "Rev", "Other"
+          ]
         },
         "claimant_first_names": {
           "$id": "#/properties/data/properties/claimantIndType/properties/claimant_first_names",
@@ -100,9 +102,11 @@
               "title": "The Claimant_gender Schema",
               "default": "",
               "examples": [
-                "Male"
+                "MALE"
               ],
-              "pattern": "^(.*)$"
+              "enum": [
+                "Male", "Femaie", "Not Known", "Non-binary"
+              ]
             },
             {
               "$id": "#/properties/data/properties/claimantIndType/properties/claimant_gender",
@@ -208,7 +212,7 @@
               "examples": [
                 "01234 567890"
               ],
-              "pattern": "^(.*)$"
+              "pattern": "^(((\\+44\\s?\\d{4}|\\(?0\\d{4}\\)?)\\s?\\d{3}\\s?\\d{3})|((\\+44\\s?\\d{3}|\\(?0\\d{3}\\)?)\\s?\\d{3}\\s?\\d{4})|((\\+44\\s?\\d{2}|\\(?0\\d{2}\\)?)\\s?\\d{4}\\s?\\d{4}))(\\s?\\#(\\d{4}|\\d{3}))?$"
             },
             {
               "$id": "#/properties/data/properties/claimantType/properties/claimant_phone_number",
@@ -227,7 +231,7 @@
                 "01234 098765"
               ],
               "$id": "#/properties/data/properties/claimantType/properties/claimant_mobile_number",
-              "pattern": "^(.*)$"
+              "pattern": "^(((\\+44\\s?\\d{4}|\\(?0\\d{4}\\)?)\\s?\\d{3}\\s?\\d{3})|((\\+44\\s?\\d{3}|\\(?0\\d{3}\\)?)\\s?\\d{3}\\s?\\d{4})|((\\+44\\s?\\d{2}|\\(?0\\d{2}\\)?)\\s?\\d{4}\\s?\\d{4}))(\\s?\\#(\\d{4}|\\d{3}))?$"
             },
             {
               "type": "null"
@@ -262,7 +266,7 @@
               "examples": [
                 "Email"
               ],
-              "pattern": "^(.*)$"
+              "enum": ["Email", "Post"]
             },
             {
               "$id": "#/properties/data/properties/claimantType/properties/claimant_contact_preference",
@@ -363,7 +367,7 @@
           "examples": [
             "03333 423554"
           ],
-          "pattern": "^(.*)$"
+          "pattern": "^(((\\+44\\s?\\d{4}|\\(?0\\d{4}\\)?)\\s?\\d{3}\\s?\\d{3})|((\\+44\\s?\\d{3}|\\(?0\\d{3}\\)?)\\s?\\d{3}\\s?\\d{4})|((\\+44\\s?\\d{2}|\\(?0\\d{2}\\)?)\\s?\\d{4}\\s?\\d{4}))(\\s?\\#(\\d{4}|\\d{3}))?$"
         }
       }
     },
@@ -524,7 +528,7 @@
           "examples": [
             "01111 123456"
           ],
-          "pattern": "^(.*)$"
+          "pattern": "^(((\\+44\\s?\\d{4}|\\(?0\\d{4}\\)?)\\s?\\d{3}\\s?\\d{3})|((\\+44\\s?\\d{3}|\\(?0\\d{3}\\)?)\\s?\\d{3}\\s?\\d{4})|((\\+44\\s?\\d{2}|\\(?0\\d{2}\\)?)\\s?\\d{4}\\s?\\d{4}))(\\s?\\#(\\d{4}|\\d{3}))?$"
         },
         "representative_mobile_number": {
           "$id": "#/properties/data/properties/representativeClaimantType/properties/representative_mobile_number",
@@ -663,7 +667,7 @@
                   "examples": [
                     "02222 321654"
                   ],
-                  "pattern": "^(.*)$"
+                  "pattern": "^(((\\+44\\s?\\d{4}|\\(?0\\d{4}\\)?)\\s?\\d{3}\\s?\\d{3})|((\\+44\\s?\\d{3}|\\(?0\\d{3}\\)?)\\s?\\d{3}\\s?\\d{4})|((\\+44\\s?\\d{2}|\\(?0\\d{2}\\)?)\\s?\\d{4}\\s?\\d{4}))(\\s?\\#(\\d{4}|\\d{3}))?$"
                 },
                 {
                   "$id": "#/properties/data/properties/respondentCollection/items/properties/value/properties/respondent_phone1",


### PR DESCRIPTION
RST-2270 (CCD) - In preparation for the capitalisation - the test suite has now replaced the validation in fake ccd with json schema validation