### PR TITLE
RST-2425 - Now using dotenv to load env vars coming from full system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 
 /.idea
 .DS_Store
+.env
+.env.local

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'addressable', '~> 2.6'
 gem 'rest-client', '~> 2.1'
 gem 'jbuilder', '~> 2.9', '>= 2.9.1'
 gem 'et_ccd_client', git: 'https://github.com/hmcts/et-ccd-client-ruby.git', tag: 'v0.1.54'
+gem 'dotenv-rails', '~> 2.7'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     et_fake_ccd (1.0.1)
       activemodel (>= 5.2.3)
@@ -284,6 +288,7 @@ DEPENDENCIES
   azure_env_secrets!
   bootsnap (>= 1.1.0)
   byebug
+  dotenv-rails (~> 2.7)
   et_ccd_client!
   et_fake_ccd (~> 1.0)
   factory_bot (~> 5.0, >= 5.0.2)


### PR DESCRIPTION



### JIRA link (if applicable) ###
RST-2425


### Change description ###
This PR allows this application to be developed locally whilst attached to the et full system environment.  It can also be tested whilst sharing the full system's resources (database etc...) - negating the need to use separate docker support services etc...


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
