### PR TITLE
RST-2983 Ethos reference number generator now wraps around using vari…

### DIFF
--- a/app/services/ethos_reference_generator_service.rb
+++ b/app/services/ethos_reference_generator_service.rb
@@ -1,19 +1,20 @@
 # Generates a new reference number from a previous reference number
 module EthosReferenceGeneratorService
-  MAX_REF = 99999
   # @param [String] previous_reference A reference number in the format oo00000/yyyy where oo is the office number, yyyy is the year and 00000 is the sequence number
   # @return [String] The new reference number.  Note that wrap around can happen only once and to signify that it has happened, the century is set to 00 in the year
   def self.call(previous_reference)
-    match_data = previous_reference.match(/\A(\d\d)(\d{5})\/(\d{4})\z/)
-    next_ref = match_data[2].to_i + 1
-    year = match_data[3].to_i
-    raise 'All reference numbers used up' if next_ref > MAX_REF && wrapped_around(year)
+    match_data = previous_reference.match(/\A(\d\d)(\d{5,})\/(\d{4})\z/)
+    next_ref   = match_data[2].to_i + 1
+    year       = match_data[3].to_i
+    digits     = match_data[2].length
+    max_ref    = ('9' * digits ).to_i
+    raise 'All reference numbers used up' if next_ref > max_ref && wrapped_around(year)
 
-    if next_ref > MAX_REF
+    if next_ref > max_ref
       next_ref = 1
       year = wrap_around(year)
     end
-    "#{match_data[1]}#{next_ref.to_s.rjust(5, '0')}/#{year.to_s.rjust(4, '0')}"
+    "#{match_data[1]}#{next_ref.to_s.rjust(digits, '0')}/#{year.to_s.rjust(4, '0')}"
   end
 
   def self.wrapped_around(year)

--- a/spec/services/ethos_reference_generator_service_spec.rb
+++ b/spec/services/ethos_reference_generator_service_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe EthosReferenceGeneratorService do
     expect(service.call('1299999/2019')).to eql '1200001/0019'
   end
 
+  it 'wraps around correctly given 6 digits' do
+    expect(service.call('12999999/2019')).to eql '12000001/0019'
+  end
+
   it 'raises an exception if wrapped around twice' do
     expect { service.call('1299999/0019') }.to raise_exception RuntimeError, 'All reference numbers used up'
   end


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RST-2983


### Change description ###
RST-2983 Ethos reference number generator now wraps around using variable number of digits (min 5 but no max)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
